### PR TITLE
 Fix paging when filtering

### DIFF
--- a/htdocs/modulebuilder/template/myobject_list.php
+++ b/htdocs/modulebuilder/template/myobject_list.php
@@ -253,17 +253,30 @@ if (empty($conf->global->MAIN_DISABLE_FULL_SCANLIST))
 	$result = $db->query($sql);
 	$nbtotalofrecords = $db->num_rows($result);
 }
-
-$sql.= $db->plimit($limit+1, $offset);
-
-$resql=$db->query($sql);
-if (! $resql)
+if (($page * $limit) > $nbtotalofrecords) 
 {
-	dol_print_error($db);
-	exit;
+	$page = 0;
+	$offset = 0; 
 }
+// if total resultset is smaller the limit, no need to do paging.
+if ($limit > $nbtotalofrecords)
+{
+	$resql = $result;
+	$num = $nbtotalofrecords;
+} 
+else 
+{
+	$sql.= $db->plimit($limit+1, $offset);
 
-$num = $db->num_rows($resql);
+	$resql=$db->query($sql);
+	if (! $resql)
+	{
+		dol_print_error($db);
+		exit;
+	}
+
+	$num = $db->num_rows($resql);
+}
 
 // Direct jump if only one record found
 if ($num == 1 && ! empty($conf->global->MAIN_SEARCH_DIRECT_OPEN_IF_ONLY_ONE) && $search_all)
@@ -317,7 +330,7 @@ if ($user->rights->mymodule->delete) $arrayofmassactions['predelete']=$langs->tr
 if (in_array($massaction, array('presend','predelete'))) $arrayofmassactions=array();
 $massactionbutton=$form->selectMassAction('', $arrayofmassactions);
 
-print '<form method="POST" id="searchFormList" action="'.$_SERVER["PHP_SELF"].'?page=0">';
+print '<form method="POST" id="searchFormList" action="'.$_SERVER["PHP_SELF"].'">';
 if ($optioncss != '') print '<input type="hidden" name="optioncss" value="'.$optioncss.'">';
 print '<input type="hidden" name="token" value="'.$_SESSION['newtoken'].'">';
 print '<input type="hidden" name="formfilteraction" id="formfilteraction" value="list">';

--- a/htdocs/modulebuilder/template/myobject_list.php
+++ b/htdocs/modulebuilder/template/myobject_list.php
@@ -253,6 +253,7 @@ if (empty($conf->global->MAIN_DISABLE_FULL_SCANLIST))
 	$result = $db->query($sql);
 	$nbtotalofrecords = $db->num_rows($result);
 }
+// if total resultset is smaller then paging size (filtering), goto and load page 0 
 if (($page * $limit) > $nbtotalofrecords) 
 {
 	$page = 0;


### PR DESCRIPTION
If total resultset is smaller then paging size (filtering), goto and
load page 0.
If total resultset is smaller the limit, no need to do paging.